### PR TITLE
Improve Swagger Documentation for Delete Product Service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,12 @@
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.3.0</version>
 		</dependency>
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>3.0.2</version>
+		</dependency>
+
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/java/com/mipagina/delete_product_service/config/OpenAPIConfig.java
+++ b/src/main/java/com/mipagina/delete_product_service/config/OpenAPIConfig.java
@@ -7,6 +7,10 @@ import io.swagger.v3.oas.models.info.License;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Configuration class for OpenAPI documentation.
+ * This class defines metadata for the Delete Product Service API.
+ */
 @Configuration
 public class OpenAPIConfig {
 

--- a/src/main/java/com/mipagina/delete_product_service/controller/ProductController.java
+++ b/src/main/java/com/mipagina/delete_product_service/controller/ProductController.java
@@ -18,9 +18,15 @@ public class ProductController {
     @Autowired
     private IProductService productService;
 
+    /**
+     * Deletes a product by its unique identifier.
+     *
+     * @param id_product The unique identifier of the product to delete.
+     */
     @Operation(
             summary = "Delete a product by ID",
-            description = "Remove a specific product from the system using its unique identifier"
+            description = "Remove a specific product from the system using its unique identifier. " +
+                    "Note that the product cannot be deleted if it is associated with an existing category."
     )
     @ApiResponses({
             @ApiResponse(
@@ -32,13 +38,17 @@ public class ProductController {
                     description = "Product not found"
             ),
             @ApiResponse(
+                    responseCode = "400",
+                    description = "Bad request, missing required fields"
+            ),
+            @ApiResponse(
                     responseCode = "500",
                     description = "Internal server error"
             )
     })
     @DeleteMapping("/products/{id_product}")
     public void deleteProduct(
-            @Parameter(description = "ID of the product to delete")
+            @Parameter(description = "ID of the product to delete", example = "5")
             @PathVariable Long id_product
     ) {
         productService.deleteProduct(id_product);

--- a/src/main/java/com/mipagina/delete_product_service/model/Product.java
+++ b/src/main/java/com/mipagina/delete_product_service/model/Product.java
@@ -7,7 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 @Entity
-@Schema(description = "Product entity representing a product in the restaurant menu")
+@Schema(description = "Product entity representing a product in the system")
 public class Product {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,7 +23,8 @@ public class Product {
     @Schema(description = "Price of the product", example = "12.99")
     private Double price;
 
-    @Schema(description = "Category ID to which the product belongs (e.g., appetizer, main course, dessert)", example = "2")
+    @Schema(description = "Category ID to which the product belongs (e.g., appetizer, main course, dessert). \n " +
+            "This field is mandatory because a product cannot be deleted if it belongs to an active category.", example = "2")
     private Long id_category;
 
     @Schema(description = "Product availability status", example = "true")


### PR DESCRIPTION
Enhanced the Delete Product Service API documentation with Swagger by adding metadata, contact information  and model annotations. This improves clarity and usability for developers.

Reviewer: @JuanGuevara90